### PR TITLE
Fix: Failing evaluation due to different NDArray dimensions

### DIFF
--- a/texoo-sector/src/main/java/de/datexis/sector/SectorAnnotator.java
+++ b/texoo-sector/src/main/java/de/datexis/sector/SectorAnnotator.java
@@ -306,7 +306,7 @@ public class SectorAnnotator extends Annotator {
     // attach PRED vectors and labels from empty Annotations
     for(SectionAnnotation ann : doc.getAnnotations(Annotation.Source.PRED, SectionAnnotation.class)) {
       int count = 0;
-      INDArray pred = Nd4j.zeros(targetEncoder.getEmbeddingVectorSize(), 1);
+      INDArray pred = Nd4j.zeros(1,targetEncoder.getEmbeddingVectorSize());
       for(Sentence s : doc.streamSentencesInRange(ann.getBegin(), ann.getEnd(), false).collect(Collectors.toList())) {
         pred.addi(s.getVector(targetEncoder.getClass()));
         count++;

--- a/texoo-sector/src/main/java/de/datexis/sector/eval/ClassificationEvaluation.java
+++ b/texoo-sector/src/main/java/de/datexis/sector/eval/ClassificationEvaluation.java
@@ -91,7 +91,7 @@ public class ClassificationEvaluation extends AnnotatorEvaluation implements IEv
         if(predicted.isPresent()) {
           matched.put(predicted.get(), true);
           INDArray r = expected.getVector(encoder.getClass()).transpose();
-          INDArray p = predicted.get().getVector(encoder.getClass()).transpose();
+          INDArray p = predicted.get().getVector(encoder.getClass()); //.transpose();
           evalExample(r, p);
         } else {
           log.warn("Could not match predicted Annotation for expected Annotation {}-{}", expected.getBegin(), expected.getEnd());
@@ -104,7 +104,7 @@ public class ClassificationEvaluation extends AnnotatorEvaluation implements IEv
           Optional<? extends Annotation> expected = doc.getAnnotationMaxOverlap(expectedSource, annotationClass, predicted);
           if(expected.isPresent()) {
             INDArray r = expected.get().getVector(encoder.getClass()).transpose();
-            INDArray p = predicted.getVector(encoder.getClass()).transpose();
+            INDArray p = predicted.getVector(encoder.getClass());//.transpose();
             evalExample(r, p);
           } 
         }


### PR DESCRIPTION
In beta4 the order of rows and columns was changed for the default creation of INDArrays. 
The SECTOR-Evaluation failed because of mismatching array dimensions.